### PR TITLE
Add event creation page with Redux

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,11 @@
       "name": "cochonnet-18",
       "version": "0.0.0",
       "dependencies": {
+        "@reduxjs/toolkit": "^2.8.2",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-redux": "^9.2.0",
+        "react-router-dom": "^7.7.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
@@ -1060,6 +1063,32 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.8.2.tgz",
+      "integrity": "sha512-MYlOhQ0sLdw4ud48FoC5w0dH9VfWQjtCjreKwYTT3l+r427qYC5Y8PihNutepr8XrNaBUDQo9khWUwQxZaqt5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1347,6 +1376,18 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1410,7 +1451,7 @@
       "version": "19.1.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -1425,6 +1466,12 @@
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.37.0",
@@ -1927,6 +1974,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1946,7 +2002,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -2427,6 +2483,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -2889,6 +2955,29 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -2898,6 +2987,65 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/react-router": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.7.0.tgz",
+      "integrity": "sha512-3FUYSwlvB/5wRJVTL/aavqHmfUKe0+Xm9MllkYgGo9eDwNdkvwlJGjpPxono1kCycLt6AnDTgjmXvK3/B4QGuw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.7.0.tgz",
+      "integrity": "sha512-wwGS19VkNBkneVh9/YD0pK3IsjWxQUVMDD6drlG7eJpo1rXBtctBqDyBm/k+oKHRAm1x9XWT3JFC82QI9YOXXA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.7.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -2999,6 +3147,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -3220,6 +3374,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@reduxjs/toolkit": "^2.8.2",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-redux": "^9.2.0",
+    "react-router-dom": "^7.7.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/src/App.css
+++ b/src/App.css
@@ -1,16 +1,83 @@
 #root {
   display: flex;
-  flex-direction: row;
   justify-content: center;
   align-items: center;
-  max-width: 100%;
-  margin: 0 auto;
+  flex-direction: column;
   text-align: center;
   background-color: white;
   color: black;
+  min-height: 100vh;
 }
 
 .App-logo {
   height: 40vmin;
   pointer-events: none;
+}
+
+.create-button {
+  background-color: #a43523;
+  color: white;
+}
+
+.config-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.config-container {
+  display: flex;
+  gap: 2rem;
+  max-height: 60vh;
+}
+
+.left-panel,
+.right-panel {
+  display: flex;
+  flex-direction: column;
+  width: 300px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1rem;
+  align-items: flex-start;
+}
+
+.team-header {
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+}
+
+.team-list-container {
+  flex: 1;
+  overflow-y: auto;
+  margin-bottom: 0.5rem;
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+}
+
+.team-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.team-add {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.start-button {
+  background-color: #a43523;
+  color: white;
+}
+
+.home-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,16 @@
-import Logo from "/logo.png";
-import "./App.css";
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import Home from './pages/Home';
+import EventConfig from './pages/EventConfig';
+import './App.css';
 
 function App() {
   return (
-    <>
-      <img src={Logo} className="App-logo" alt="logo" />
-      <div>
-        <h1>Cochonnet-18</h1>
-        <p>Logiciel de gestion de tournoi de pétanque</p>
-      </div>
-    </>
+    <Router>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/config" element={<EventConfig />} />
+      </Routes>
+    </Router>
   );
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
-import Home from './pages/Home';
-import EventConfig from './pages/EventConfig';
-import './App.css';
+import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import Home from "./pages/Home";
+import EventConfig from "./pages/EventConfig";
+import "./App.css";
 
 function App() {
   return (

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,13 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.tsx";
+import { Provider } from "react-redux";
+import { store } from "./store";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <App />
+    <Provider store={store}>
+      <App />
+    </Provider>
   </StrictMode>
 );

--- a/src/pages/EventConfig.tsx
+++ b/src/pages/EventConfig.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import { useAppDispatch, useAppSelector } from '../store/hooks';
+import { addTeam, setMatches, setName } from '../store/eventSlice';
+import '../App.css';
+
+function EventConfig() {
+  const dispatch = useAppDispatch();
+  const { name, matches, teams } = useAppSelector((state) => state.event);
+  const [newTeam, setNewTeam] = useState('');
+
+  const handleAddTeam = () => {
+    if (newTeam.trim()) {
+      dispatch(addTeam(newTeam));
+      setNewTeam('');
+    }
+  };
+
+  return (
+    <div className="config-wrapper">
+      <div className="config-container">
+        <div className="left-panel">
+          <div className="field">
+            <label>Nom de l&apos;évènement</label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => dispatch(setName(e.target.value))}
+            />
+          </div>
+          <div className="field">
+            <label>Nombre de matchs par équipe</label>
+            <input
+              type="number"
+              min={1}
+              value={matches}
+              onChange={(e) => dispatch(setMatches(Number(e.target.value)))}
+            />
+          </div>
+        </div>
+        <div className="right-panel">
+          <div className="team-header">{teams.length} équipes</div>
+          <div className="team-list-container">
+            <ul className="team-list">
+              {teams.map((team) => (
+                <li key={team}>{team}</li>
+              ))}
+            </ul>
+          </div>
+          <div className="team-add">
+            <input
+              type="text"
+              value={newTeam}
+              placeholder="Nom de l'équipe"
+              onChange={(e) => setNewTeam(e.target.value)}
+            />
+            <button onClick={handleAddTeam}>Ajouter</button>
+          </div>
+        </div>
+      </div>
+      <button className="start-button">Démarrer</button>
+    </div>
+  );
+}
+
+export default EventConfig;

--- a/src/pages/EventConfig.tsx
+++ b/src/pages/EventConfig.tsx
@@ -1,17 +1,17 @@
-import { useState } from 'react';
-import { useAppDispatch, useAppSelector } from '../store/hooks';
-import { addTeam, setMatches, setName } from '../store/eventSlice';
-import '../App.css';
+import { useState } from "react";
+import { useAppDispatch, useAppSelector } from "../store/hooks";
+import { addTeam, setMatches, setName } from "../store/eventSlice";
+import "../App.css";
 
 function EventConfig() {
   const dispatch = useAppDispatch();
   const { name, matches, teams } = useAppSelector((state) => state.event);
-  const [newTeam, setNewTeam] = useState('');
+  const [newTeam, setNewTeam] = useState("");
 
   const handleAddTeam = () => {
     if (newTeam.trim()) {
       dispatch(addTeam(newTeam));
-      setNewTeam('');
+      setNewTeam("");
     }
   };
 
@@ -20,10 +20,11 @@ function EventConfig() {
       <div className="config-container">
         <div className="left-panel">
           <div className="field">
-            <label>Nom de l&apos;évènement</label>
+            <label>Nom de l'évènement</label>
             <input
               type="text"
               value={name}
+              placeholder="Nom de l'évènement"
               onChange={(e) => dispatch(setName(e.target.value))}
             />
           </div>
@@ -33,6 +34,7 @@ function EventConfig() {
               type="number"
               min={1}
               value={matches}
+              placeholder="Nombre de matchs"
               onChange={(e) => dispatch(setMatches(Number(e.target.value)))}
             />
           </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,6 @@
-import { Link } from 'react-router-dom';
-import Logo from '/logo.png';
-import '../App.css';
+import { Link } from "react-router-dom";
+import Logo from "/logo.png";
+import "../App.css";
 
 function Home() {
   return (

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,20 @@
+import { Link } from 'react-router-dom';
+import Logo from '/logo.png';
+import '../App.css';
+
+function Home() {
+  return (
+    <div id="home" className="home-container">
+      <img src={Logo} className="App-logo" alt="logo" />
+      <div>
+        <h1>Cochonnet-18</h1>
+        <p>Logiciel de gestion de tournoi de pétanque</p>
+        <Link to="/config">
+          <button className="create-button">Créer un évènement</button>
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+export default Home;

--- a/src/store/eventSlice.ts
+++ b/src/store/eventSlice.ts
@@ -1,0 +1,36 @@
+import { createSlice } from '@reduxjs/toolkit';
+import type { PayloadAction } from '@reduxjs/toolkit';
+
+export interface EventState {
+  name: string;
+  matches: number;
+  teams: string[];
+}
+
+const initialState: EventState = {
+  name: '',
+  matches: 1,
+  teams: [],
+};
+
+const eventSlice = createSlice({
+  name: 'event',
+  initialState,
+  reducers: {
+    setName(state, action: PayloadAction<string>) {
+      state.name = action.payload;
+    },
+    setMatches(state, action: PayloadAction<number>) {
+      state.matches = action.payload;
+    },
+    addTeam(state, action: PayloadAction<string>) {
+      const team = action.payload.trim();
+      if (team && !state.teams.includes(team)) {
+        state.teams.push(team);
+      }
+    },
+  },
+});
+
+export const { setName, setMatches, addTeam } = eventSlice.actions;
+export default eventSlice.reducer;

--- a/src/store/eventSlice.ts
+++ b/src/store/eventSlice.ts
@@ -1,5 +1,5 @@
-import { createSlice } from '@reduxjs/toolkit';
-import type { PayloadAction } from '@reduxjs/toolkit';
+import { createSlice } from "@reduxjs/toolkit";
+import type { PayloadAction } from "@reduxjs/toolkit";
 
 export interface EventState {
   name: string;
@@ -8,13 +8,13 @@ export interface EventState {
 }
 
 const initialState: EventState = {
-  name: '',
+  name: "",
   matches: 1,
   teams: [],
 };
 
 const eventSlice = createSlice({
-  name: 'event',
+  name: "event",
   initialState,
   reducers: {
     setName(state, action: PayloadAction<string>) {

--- a/src/store/hooks.ts
+++ b/src/store/hooks.ts
@@ -1,0 +1,6 @@
+import { useDispatch, useSelector } from 'react-redux';
+import type { TypedUseSelectorHook } from 'react-redux';
+import type { RootState, AppDispatch } from './index';
+
+export const useAppDispatch: () => AppDispatch = useDispatch;
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/src/store/hooks.ts
+++ b/src/store/hooks.ts
@@ -1,6 +1,6 @@
-import { useDispatch, useSelector } from 'react-redux';
-import type { TypedUseSelectorHook } from 'react-redux';
-import type { RootState, AppDispatch } from './index';
+import { useDispatch, useSelector } from "react-redux";
+import type { TypedUseSelectorHook } from "react-redux";
+import type { RootState, AppDispatch } from "./index";
 
 export const useAppDispatch: () => AppDispatch = useDispatch;
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,11 @@
+import { configureStore } from '@reduxjs/toolkit';
+import eventReducer from './eventSlice';
+
+export const store = configureStore({
+  reducer: {
+    event: eventReducer,
+  },
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,5 +1,5 @@
-import { configureStore } from '@reduxjs/toolkit';
-import eventReducer from './eventSlice';
+import { configureStore } from "@reduxjs/toolkit";
+import eventReducer from "./eventSlice";
 
 export const store = configureStore({
   reducer: {


### PR DESCRIPTION
## Summary
- add React Router and Redux Toolkit
- configure store and hooks
- implement home page with "Créer un évènement" button
- implement event configuration page with team list
- style buttons and layout

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687dedb4ccd083229766ad0781433cb3