### PR TITLE
Add progress bar to round tabs

### DIFF
--- a/src/pages/Phase1.css
+++ b/src/pages/Phase1.css
@@ -10,7 +10,7 @@
 .phase1-content {
   flex: 1;
   display: flex;
-  gap: 1rem;
+  gap: 2rem;
   overflow: hidden;
   justify-content: center;
 }
@@ -51,6 +51,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  white-space: nowrap;
 }
 
 .progress-container {
@@ -66,7 +67,7 @@
   top: 0;
   left: 0;
   bottom: 0;
-  background-color: white;
+  background-color: gray;
 }
 
 .phase1-table {
@@ -126,9 +127,6 @@ td.score-col {
   margin: 0;
 }
 
-.score-input[type='number'] {
-  -moz-appearance: textfield;
-}
 
 .score-input:focus {
   outline: none;

--- a/src/pages/Phase1.css
+++ b/src/pages/Phase1.css
@@ -1,19 +1,72 @@
 .phase1-wrapper {
   display: flex;
   flex-direction: column;
+  width: 100%;
+  height: 100%;
+  padding: 5rem;
+  gap: 2rem;
+}
+
+.phase1-content {
+  flex: 1;
+  display: flex;
   gap: 1rem;
+  overflow: hidden;
+  justify-content: center;
+}
+
+.ranking-panel,
+.matches-panel {
+  flex: 1 1 0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  overflow: hidden;
+  gap: 1rem;
+  max-width: 650px;
+}
+
+.ranking-scroll,
+.match-table-container {
+  flex: 1;
+  overflow-y: auto;
+  width: 100%;
 }
 
 .tabs {
   display: flex;
   gap: 0.5rem;
+  overflow-x: auto;
+  width: 100%;
 }
 
 .active-tab {
   font-weight: bold;
-  text-decoration: underline;
   background-color: #fe1900d0;
   cursor: default;
+}
+
+.round-button {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.progress-container {
+  position: relative;
+  width: 90%;
+  height: 2px;
+  background-color: lightgray;
+  margin-top: 2px;
+}
+
+.progress-bar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  background-color: white;
 }
 
 .phase1-table {
@@ -24,9 +77,20 @@
   white-space: nowrap;
 }
 
+.ranking-table {
+  width: 100%;
+  border-collapse: collapse;
+  display: grid;
+  grid-template-columns: min-content auto min-content;
+  white-space: nowrap;
+}
+
 .phase1-table thead,
 .phase1-table tbody,
-.phase1-table tr {
+.phase1-table tr,
+.ranking-table thead,
+.ranking-table tbody,
+.ranking-table tr {
   display: contents;
 }
 
@@ -56,6 +120,16 @@ td.score-col {
   text-align: center;
 }
 
+.score-input::-webkit-inner-spin-button,
+.score-input::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.score-input[type='number'] {
+  -moz-appearance: textfield;
+}
+
 .score-input:focus {
   outline: none;
 }
@@ -66,4 +140,17 @@ td.score-col {
 
 .loser {
   background-color: #f8d7da;
+}
+
+.ranking-panel h2,
+.matches-panel h2 {
+  width: 100%;
+  text-align: center;
+}
+
+.divider {
+  width: 1px;
+  background-color: lightgray;
+  height: 90%;
+  align-self: center;
 }

--- a/src/pages/Phase1.tsx
+++ b/src/pages/Phase1.tsx
@@ -1,12 +1,26 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
 import { setMatchScore } from '../store/eventSlice';
+import { computeRanking } from '../utils/ranking';
 import './Phase1.css';
 
 function Phase1() {
   const dispatch = useAppDispatch();
-  const { rounds } = useAppSelector((state) => state.event);
+  const { rounds, teams } = useAppSelector((state) => state.event);
   const [activeRound, setActiveRound] = useState(0);
+
+  const ranking = useMemo(() => computeRanking(teams, rounds), [teams, rounds]);
+  const roundProgress = useMemo(
+    () =>
+      rounds.map((round) => {
+        const total = round.length;
+        const filled = round.filter(
+          (m) => m.scoreA !== undefined && m.scoreB !== undefined
+        ).length;
+        return total === 0 ? 0 : filled / total;
+      }),
+    [rounds]
+  );
 
   if (rounds.length === 0) {
     return <div>Aucun tirage n'a été généré.</div>;
@@ -45,82 +59,130 @@ function Phase1() {
 
   return (
     <div className="phase1-wrapper">
-      <div className="tabs">
-        {rounds.map((_, idx) => (
-          <button
-            type="button"
-            key={idx}
-            onClick={() => setActiveRound(idx)}
-            className={activeRound === idx ? 'active-tab' : ''}
-          >
-            Round {idx + 1}
-          </button>
-        ))}
+      <h1>Phase 1</h1>
+      <div className="phase1-content">
+        <div className="ranking-panel">
+          <h2>Classement</h2>
+          <div className="ranking-scroll">
+            <table className="ranking-table">
+              <thead>
+                <tr>
+                  <th>Classement</th>
+                  <th>Équipe</th>
+                  <th>Score</th>
+                </tr>
+              </thead>
+              <tbody>
+                {(() => {
+                  let currentRank = 0;
+                  let prevScore: number | undefined;
+                  return ranking.map((entry, idx) => {
+                    if (prevScore === undefined || entry.score !== prevScore) {
+                      currentRank = idx + 1;
+                      prevScore = entry.score;
+                    }
+                    return (
+                      <tr key={entry.team}>
+                        <td>{currentRank}</td>
+                        <td>{entry.team}</td>
+                        <td>{entry.score}</td>
+                      </tr>
+                    );
+                  });
+                })()}
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div className="divider" aria-hidden="true" />
+        <div className="matches-panel">
+          <h2>Matchs</h2>
+          <div className="tabs">
+            {rounds.map((_, idx) => (
+              <button
+                type="button"
+                key={idx}
+                onClick={() => setActiveRound(idx)}
+                className={`${activeRound === idx ? 'active-tab' : ''} round-button`}
+              >
+                Round {idx + 1}
+                <span className="progress-container">
+                  <span
+                    className="progress-bar"
+                    style={{ width: `${roundProgress[idx] * 100}%` }}
+                  />
+                </span>
+              </button>
+            ))}
+          </div>
+          <div className="match-table-container">
+            <table className="phase1-table">
+              <thead>
+                <tr>
+                  <th>Équipe 1</th>
+                  <th className="score-col">Score 1</th>
+                  <th className="score-col">Score 2</th>
+                  <th>Équipe 2</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rounds[activeRound].map((match, idx) => (
+                  <tr key={idx}>
+                    <td>{match.teamA}</td>
+                    <td
+                      className={`score-col ${scoreClass(
+                        match.scoreA,
+                        match.scoreB,
+                        'A'
+                      )}`}
+                    >
+                      <input
+                        className="score-input"
+                        type="number"
+                        min={0}
+                        title="Score équipe 1"
+                        value={match.scoreA ?? ''}
+                        onChange={(e) =>
+                          handleScoreChange(
+                            activeRound,
+                            idx,
+                            'scoreA',
+                            e.target.value
+                          )
+                        }
+                      />
+                    </td>
+                    <td
+                      className={`score-col ${scoreClass(
+                        match.scoreA,
+                        match.scoreB,
+                        'B'
+                      )}`}
+                    >
+                      <input
+                        className="score-input"
+                        type="number"
+                        min={0}
+                        title="Score équipe 2"
+                        value={match.scoreB ?? ''}
+                        onChange={(e) =>
+                          handleScoreChange(
+                            activeRound,
+                            idx,
+                            'scoreB',
+                            e.target.value
+                          )
+                        }
+                      />
+                    </td>
+                    <td>{match.teamB}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
       </div>
-      <table className="phase1-table">
-        <thead>
-          <tr>
-            <th>Équipe 1</th>
-            <th className="score-col">Score 1</th>
-            <th className="score-col">Score 2</th>
-            <th>Équipe 2</th>
-          </tr>
-        </thead>
-        <tbody>
-          {rounds[activeRound].map((match, idx) => (
-            <tr key={idx}>
-              <td>{match.teamA}</td>
-              <td
-                className={`score-col ${scoreClass(
-                  match.scoreA,
-                  match.scoreB,
-                  'A'
-                )}`}
-              >
-                <input
-                  className="score-input"
-                  type="number"
-                  min={0}
-                  title="Score équipe 1"
-                  value={match.scoreA ?? ''}
-                  onChange={(e) =>
-                    handleScoreChange(
-                      activeRound,
-                      idx,
-                      'scoreA',
-                      e.target.value
-                    )
-                  }
-                />
-              </td>
-              <td
-                className={`score-col ${scoreClass(
-                  match.scoreA,
-                  match.scoreB,
-                  'B'
-                )}`}
-              >
-                <input
-                  className="score-input"
-                  type="number"
-                  min={0}
-                  title="Score équipe 2"
-                  value={match.scoreB ?? ''}
-                  onChange={(e) =>
-                    handleScoreChange(
-                      activeRound,
-                      idx,
-                      'scoreB',
-                      e.target.value
-                    )
-                  }
-                />
-              </td>
-              <td>{match.teamB}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
     </div>
   );
 }

--- a/src/utils/ranking.ts
+++ b/src/utils/ranking.ts
@@ -1,0 +1,33 @@
+export interface RankingEntry {
+  team: string;
+  score: number;
+}
+
+import type { Round } from './schedule';
+
+export function computeRanking(teams: string[], rounds: Round[]): RankingEntry[] {
+  const scores = new Map<string, number>();
+  teams.forEach((t) => scores.set(t, 0));
+
+  for (const round of rounds) {
+    for (const match of round) {
+      const { teamA, teamB, scoreA, scoreB } = match;
+      if (scoreA === undefined || scoreB === undefined) continue;
+      const diff = Math.abs(scoreA - scoreB);
+      if (scoreA > scoreB) {
+        scores.set(teamA, (scores.get(teamA) ?? 0) + diff);
+        scores.set(teamB, (scores.get(teamB) ?? 0) - diff);
+      } else if (scoreB > scoreA) {
+        scores.set(teamB, (scores.get(teamB) ?? 0) + diff);
+        scores.set(teamA, (scores.get(teamA) ?? 0) - diff);
+      }
+    }
+  }
+
+  const list: RankingEntry[] = teams.map((team) => ({
+    team,
+    score: scores.get(team) ?? 0,
+  }));
+  list.sort((a, b) => b.score - a.score);
+  return list;
+}


### PR DESCRIPTION
## Summary
- compute progress for each round
- display round progress bars below tab text
- remove underline from active tab buttons

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6880c7609c0c8322af1b31253e59d721